### PR TITLE
Add `eradio-{get,show}-song-title` functions

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,7 +26,9 @@ The package is available in the Melpa repository.
 ** Media player
 eradio requires an external media player such as VLC or mpv. The command to be used is determined by the =eradio-player= variable. The head of =eradio-player= is the program and the tail is the arguments. The default command uses VLC from the =exec-path= variable(which may differ from =$PATH=), but it can be customized to use mpv, VLC.app or alternatively set to use something else entirely.
 
-To use VLC.app, customize =eradio-player= to =vlc-mac= or set it to =("/Applications/VLC.app/Contents/MacOS/VLC" "--no-video" "-I" "rc")=. To use mpv, customize =eradio-player= to =mpv= or set it to =("mpv" "--no-video" "--no-terminal")=
+To use VLC.app, customize =eradio-player= to =vlc-mac= or set it to =("/Applications/VLC.app/Contents/MacOS/VLC" "--no-video" "-I" "rc")=. To use mpv, customize =eradio-player= to =mpv= or set it to ~("mpv" "--no-video" "--no-terminal" "--input-ipc-server=/tmp/eradio-socket")~
+
+Currently =eradio-{get,show}-song-title= functions only works with =mpv=.
 
 ** Keybindings
 eradio does not bind any keys by default. Therefore you should bind them yourself. The following snippets are just suggestions. You can of course use any keybindings you would like.

--- a/README.org
+++ b/README.org
@@ -28,7 +28,7 @@ eradio requires an external media player such as VLC or mpv. The command to be u
 
 To use VLC.app, customize =eradio-player= to =vlc-mac= or set it to =("/Applications/VLC.app/Contents/MacOS/VLC" "--no-video" "-I" "rc")=. To use mpv, customize =eradio-player= to =mpv= or set it to ~("mpv" "--no-video" "--no-terminal" "--input-ipc-server=/tmp/eradio-socket")~
 
-Currently =eradio-{get,show}-song-title= functions only works with =mpv=.
+Currently =eradio-{get,show}-song-title= functions only works with =mpv=. Also [[https://linux.die.net/man/1/socat][socat]] is required for these functions to work. Install it through your package manager.
 
 ** Keybindings
 eradio does not bind any keys by default. Therefore you should bind them yourself. The following snippets are just suggestions. You can of course use any keybindings you would like.


### PR DESCRIPTION
I've created this function for my needs, hence it only works with mpv (and only works with internet radios, it does not extract information from other sources). Related to #6 but does not fulfill the requirements listed on there. Leaving this here for reference, feel free to close the PR.