### PR TITLE
Let eradio-play continue playing while selecting next station

### DIFF
--- a/eradio.el
+++ b/eradio.el
@@ -87,8 +87,8 @@ This is a list of the program and its arguments.  The url will be appended to th
 (defun eradio-play (&optional url)
   "Play a radio channel, do what I mean."
   (interactive)
-  (eradio-stop)
   (let ((url (or url (eradio--get-url))))
+    (eradio-stop)
     (setq eradio-current-channel url)
     (eradio--play-low-level url)))
 


### PR DESCRIPTION
When eradio is already playing, invoking `eradio-play` stops playing immediately, so you can't `C-g` out and
have playing be uninterrupted. Let's delay the call to `eradio-stop` until after we have the next URL.
