### PR TITLE
Check whether the target URL is available

### DIFF
--- a/eradio.el
+++ b/eradio.el
@@ -88,9 +88,12 @@ This is a list of the program and its arguments.  The url will be appended to th
   "Play a radio channel, do what I mean."
   (interactive)
   (let ((url (or url (eradio--get-url))))
-    (eradio-stop)
-    (setq eradio-current-channel url)
-    (eradio--play-low-level url)))
+    (if (url-file-exists-p url)
+	(progn 
+	  (eradio-stop)
+	  (setq eradio-current-channel url)
+	  (eradio--play-low-level url))
+      (message "file doesn't exist: %s" url))))
 
 (provide 'eradio)
 ;;; eradio.el ends here


### PR DESCRIPTION
Sometimes URL may be broken. In this case, `eradio-play` will stop the stream being played and will silently be unable to play the newly selected stream. 

Fix this issue by checking the availability of the URL before doing any action aforementioned. If the URL is not available, warn the user and do not interrupt the current stream.